### PR TITLE
Fix invalid JSON handling

### DIFF
--- a/src/backend/api/routes/gen_config.py
+++ b/src/backend/api/routes/gen_config.py
@@ -79,7 +79,9 @@ def parse_config_str(s):
 
 @gen_config_bp.route("/gen_config", methods=["POST"])
 def generate_config():
-    request_json = request.get_json()
+    request_json = request.get_json(silent=True)
+    if request_json is None:
+        return jsonify({"message": "invalid JSON"}), 400
     temperature = float(request_json.get("temperature", 1.0))
     top_p       = float(request_json.get("top_p", 1.0))
 

--- a/src/backend/tests/unit/test_api_routes.py
+++ b/src/backend/tests/unit/test_api_routes.py
@@ -77,10 +77,18 @@ class TestGenConfigRoute:
     def test_generate_config_missing_desc(self, client):
         """Test config generation with missing description."""
         response = client.post('/sim/gen_config', json={})
-        
+
         assert response.status_code == 400
         data = response.get_json()
         assert "desc not given" in data["message"]
+
+    def test_generate_config_invalid_json(self, client):
+        """Test config generation with malformed JSON body."""
+        response = client.post('/sim/gen_config', data='{"desc":', content_type='application/json')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "invalid JSON" in data["message"]
     
     @patch('api.routes.gen_config.client_for_endpoint')
     def test_generate_config_client_failure(self, mock_client_func, client):


### PR DESCRIPTION
## Summary
- handle malformed JSON in `generate_config` route
- add regression test for invalid JSON

## Testing
- `pytest src/backend/tests/unit/test_api_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858feee6f1c83318d5e9bbb8d2348a5